### PR TITLE
YAML file for R Group Replacements

### DIFF
--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -4,7 +4,7 @@ description: 'Uses the Top 500 R Group replacement data of Bajorath et al. to su
 category: Chemistry
 version: 1.0.0
 serviceName: RGroupReplacement
-serviceUri: glysade.python
+serviceUri: PYRO:glysade.pyserver@127.0.0.1:9101
 executorId: Glysade.CPythonDataFxn
 inputFields:
 - control:

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -85,7 +85,7 @@ tags:
 - color: '#c6fc00'
   text: calcprop
 updateBehavior: automatic
-maximumOutputColumns: !!int 0
+maximumOutputColumns: !!int 1
 maximumOutputTables: !!int 1
 chemistryFunction: !!bool false
 outputFields:

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -49,20 +49,23 @@ inputFields:
     data: !!bool false
 - control:
     id: coreSketcher
-    label: Reaction query
+    label: Core query
     type: molecule
-    sketcherContentType: chemical/x-mdl-rxnfile
+    sketcherContentType: chemical/x-mdl-molfile
     molTypes:
     - extension: .sma
       contentType: chemical/x-smarts
       name: SMARTS (*.sma)
-    - extension: .rxn
-      contentType: chemical/x-mdl-rxnfile
-      name: RXN file (*.rxn)
+    - extension: .mol
+      contentType: chemical/x-mdl-molfile
+      name: MOL file (*.mol)
+    - extension: .sdf
+      contentType: chemical/x-mdl-molfile
+      name: SD file (*.sdf)
   request:
     id: coreSketcher
     dataType: string
-    contentType: chemical/x-mdl-rxnfile
+    contentType: chemical/x-mdl-molfile
 tags:
 - color: '#50AF28'
   text: chemistry

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -37,6 +37,7 @@ inputFields:
   request:
     id: useLayer1
     dataType: boolean
+    data: !!bool true
 - control:
     id: useLayer2
     label: User Layer 2 replacements
@@ -45,6 +46,7 @@ inputFields:
   request:
     id: useLayer2
     dataType: boolean
+    data: !!bool false
 - control:
     id: coreSMARTS
     label: SMARTS defining core of molecules

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -66,7 +66,7 @@ inputFields:
     selectorType: column
 - control:
     id: rGroupColumns
-    label: R Group columns
+    label: R Group columns to replace
     type: columnselect
     multi: !!bool true
     filters:
@@ -86,36 +86,9 @@ inputFields:
       contentType: chemical/x-daylight-smiles
     validationRules:
     - type: required
-    tooltip: Select all the R Group columns from the R Group Decomposition that are in the table
+    tooltip: Select all the R Group columns from the R Group Decomposition.  These groups will be replaced by Top 500 replacements.
   request:
     id: rGroupColumns
-    dataType: list(string)
-    selectorType: column
-- control:
-    id: columnsToUse
-    label: R Group columns to use
-    type: columnselect
-    multi: !!bool true
-    filters:
-    - dataType:
-      - binary
-      contentType:
-      - chemical/x-mdl-molfile
-      - chemical/x-mdl-molfile-v3000
-    - dataType: string
-      contentType:
-      - chemical/x-mdl-molfile
-      - chemical/x-mdl-molfile-v3000
-    - dataType: string
-      contentType:
-      - chemical/x-smiles
-    - dataType: string
-      contentType: chemical/x-daylight-smiles
-    validationRules:
-    - type: required
-    tooltip: Select the R Groups to be replaced
-  request:
-    id: columnsToUse
     dataType: list(string)
     selectorType: column
 - control:

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -61,6 +61,15 @@ inputFields:
     dataType: boolean
     data: !!bool false
 - control:
+    id: incOrigRGroups
+    label: Include original R Groups
+    type: checkbox
+    tooltip: When doing the replacements, include the original R Group in the substitution list, so that no change at that position is included in the products.
+  request:
+    id: incOrigRGroups
+    dataType: boolean
+    data: !!bool false
+- control:
     id: coreSketcher
     label: Core query
     type: molecule

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -48,32 +48,21 @@ inputFields:
     dataType: boolean
     data: !!bool false
 - control:
-    id: coreSMARTS
-    label: SMARTS defining core of molecules
-    type: text
-    tooltip: A core is needed so the R Groups can be identified.
-  request:
-    id: coreSMARTS
-    dataType: string
-- control:
     id: coreSketcher
-    label: Sketch defining core
+    label: Reaction query
     type: molecule
+    sketcherContentType: chemical/x-mdl-rxnfile
     molTypes:
-    - extension: .smi
-      contentType: smiles
-      name: SMILES (*.smi)
-    - extension: .sdf
-      contentType: chemical/x-mdl-sdfile
-      name: SD file (*.sdf)
-    - extension: .mol
-      contentType: chemical/x-mdl-molfile
-      name: MOL file (*.mol)
-    tooltip: Note that this is a query molecule, so aromatic rings must be specified correctly.
+    - extension: .sma
+      contentType: chemical/x-smarts
+      name: SMARTS (*.sma)
+    - extension: .rxn
+      contentType: chemical/x-mdl-rxnfile
+      name: RXN file (*.rxn)
   request:
     id: coreSketcher
     dataType: string
-    contentType: chemical/x-mdl-molfile
+    contentType: chemical/x-mdl-rxnfile
 tags:
 - color: '#50AF28'
   text: chemistry

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -92,7 +92,7 @@ inputFields:
     dataType: list(string)
     selectorType: column
 - control:
-    id: rGroupColumnsToUse
+    id: columnsToUse
     label: R Group columns to use
     type: columnselect
     multi: !!bool true
@@ -115,7 +115,7 @@ inputFields:
     - type: required
     tooltip: Select the R Groups to use be replaced
   request:
-    id: rGroupColumnsToUse
+    id: columnsToUse
     dataType: list(string)
     selectorType: column
 - control:

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -155,10 +155,10 @@ maximumOutputColumns: !!int 1
 maximumOutputTables: !!int 1
 chemistryFunction: !!bool false
 outputFields:
-- id: table1
-  source: table
-  type: default
-  name: Output R Group Replacements table
+  - id: table1
+    source: table
+    type: default
+    name: Output R Group Replacements table
 allowedClients:
 - Analyst
 - WebPlayer

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -43,6 +43,52 @@ inputFields:
     dataType: string
     selectorType: column
 - control:
+    id: coresColumn
+    label: Select Cores column
+    type: columnselect
+    filters:
+    - dataType: string
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+      - chemical/x-smiles
+      - chemical/x-daylight-smiles
+    - dataType: binary
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+    validationRules:
+    - type: required
+      message: Must select column of 2D structures
+  request:
+    id: coresColumn
+    dataType: string
+    selectorType: column
+- control:
+    id: rGroupColumns
+    label: R Group columns
+    type: columnselect
+    multi: !!bool true
+    filters:
+    - dataType: binary
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+    - dataType: string
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+    - dataType: string
+      contentType: chemical/x-smiles
+    - dataType: string
+      contentType: chemical/x-daylight-smiles
+    validationRules:
+    - type: required
+  request:
+    id: rGroupColumns
+    dataType: list(string)
+    selectorType: column
+- control:
     id: useLayer1
     label: Use Layer 1 replacements
     type: checkbox

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -87,8 +87,6 @@ inputFields:
     - dataType: string
       contentType: chemical/x-daylight-smiles
     validationRules:
-    - type: required
-      message: Must select at least 1 column of R Groups
     - type: oneOrMoreRequired
       message: Must select at least 1 column of R Groups
     tooltip: Select all the R Group columns from the R Group Decomposition.  These groups will be replaced by Top 500 replacements.

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -1,4 +1,4 @@
-id: 0227312a-b83e-9777-d285-196c05263676
+id: 2abb2403-f1f4-4f52-4695-e5f5ce1bc9a8
 name: R Group Replacement
 description: 'Uses the Top 500 R Group replacement data of Bajorath et al. to produce analogues of the input molecules. '
 category: Chemistry
@@ -69,9 +69,9 @@ inputFields:
     label: All R Group columns
     type: columnselect
     multi: !!bool true
-    tooltip: Select all the R Group columns from the R Group Decomposition that are in the table
     filters:
-    - dataType: binary
+    - dataType:
+      - binary
       contentType:
       - chemical/x-mdl-molfile
       - chemical/x-mdl-molfile-v3000
@@ -80,11 +80,13 @@ inputFields:
       - chemical/x-mdl-molfile
       - chemical/x-mdl-molfile-v3000
     - dataType: string
-      contentType: chemical/x-smiles
+      contentType:
+      - chemical/x-smiles
     - dataType: string
       contentType: chemical/x-daylight-smiles
     validationRules:
     - type: required
+    tooltip: Select all the R Group columns from the R Group Decomposition that are in the table
   request:
     id: allRGroupColumns
     dataType: list(string)
@@ -95,8 +97,10 @@ inputFields:
     type: columnselect
     multi: !!bool true
     tooltip: Select the R Group columns that you want to be varied in the output molecules.  The remainder will be kept as the original value from the parent molecule.  If left blank, all R Groups will be varied.
+    validationRules: []
     filters:
-    - dataType: binary
+    - dataType:
+      - binary
       contentType:
       - chemical/x-mdl-molfile
       - chemical/x-mdl-molfile-v3000
@@ -105,11 +109,11 @@ inputFields:
       - chemical/x-mdl-molfile
       - chemical/x-mdl-molfile-v3000
     - dataType: string
-      contentType: chemical/x-smiles
+      contentType:
+      - chemical/x-smiles
     - dataType: string
-      contentType: chemical/x-daylight-smiles
-    validationRules:
-    - type: required
+      contentType:
+      - chemical/x-daylight-smiles
   request:
     id: rGroupColumnsToUse
     dataType: list(string)
@@ -151,10 +155,10 @@ maximumOutputColumns: !!int 1
 maximumOutputTables: !!int 1
 chemistryFunction: !!bool false
 outputFields:
-  - id: table1
-    source: table
-    type: default
-    name: Output R Group Replacements table
+- id: table1
+  source: table
+  type: default
+  name: Output R Group Replacements table
 allowedClients:
 - Analyst
 - WebPlayer

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -1,6 +1,6 @@
 id: 2abb2403-f1f4-4f52-4695-e5f5ce1bc9a8
 name: R Group Replacement
-description: 'Uses the Top 500 R Group replacement data of Bajorath et al. to produce analogues of the input molecules. '
+description: 'AUses the Top 500 R Group replacement data of Bajorath et al. to produce analogues of the input molecules. '
 category: Chemistry
 version: 1.0.0
 serviceName: RGroupReplacement
@@ -113,7 +113,7 @@ inputFields:
       contentType: chemical/x-daylight-smiles
     validationRules:
     - type: required
-    tooltip: Select the R Groups to use be replaced
+    tooltip: Select the R Groups to be replaced
   request:
     id: columnsToUse
     dataType: list(string)

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -4,7 +4,7 @@ description: 'Uses the Top 500 R Group replacement data of Bajorath et al. to su
 category: Chemistry
 version: 1.0.0
 serviceName: RGroupReplacement
-serviceUri: PYRO:glysade.pyserver@127.0.0.1:9101
+serviceUri: glysade.python
 executorId: Glysade.CPythonDataFxn
 inputFields:
 - control:

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -1,6 +1,6 @@
 id: 0227312a-b83e-9777-d285-196c05263676
 name: R Group Replacement
-description: 'Uses the Top 500 R Group replacement data of Bajorath et al. to suggest produce analogues of the input molecules. '
+description: 'Uses the Top 500 R Group replacement data of Bajorath et al. to produce analogues of the input molecules. '
 category: Chemistry
 version: 1.0.0
 serviceName: RGroupReplacement

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -115,25 +115,6 @@ inputFields:
     id: incOrigRGroups
     dataType: boolean
     data: !!bool false
-- control:
-    id: coreSketcher
-    label: Core query
-    type: molecule
-    sketcherContentType: chemical/x-mdl-molfile
-    molTypes:
-    - extension: .sma
-      contentType: chemical/x-smarts
-      name: SMARTS (*.sma)
-    - extension: .mol
-      contentType: chemical/x-mdl-molfile
-      name: MOL file (*.mol)
-    - extension: .sdf
-      contentType: chemical/x-mdl-molfile
-      name: SD file (*.sdf)
-  request:
-    id: coreSketcher
-    dataType: string
-    contentType: chemical/x-mdl-molfile
 tags:
 - color: '#50AF28'
   text: chemistry

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -1,6 +1,6 @@
 id: 2abb2403-f1f4-4f52-4695-e5f5ce1bc9a8
 name: R Group Replacement
-description: 'AUses the Top 500 R Group replacement data of Bajorath et al. to produce analogues of the input molecules. '
+description: 'Uses the Top 500 R Group replacement data of Bajorath et al. to produce analogues of the input molecules based on output from an R Group Decomposition. '
 category: Chemistry
 version: 1.0.0
 serviceName: RGroupReplacement
@@ -11,6 +11,7 @@ inputFields:
     id: structureColumn
     label: Select structure column
     type: columnselect
+    tooltip: Select column of strutures that the R Group Decomposition was performed on.
     filters:
     - dataType: string
       contentType:
@@ -59,14 +60,14 @@ inputFields:
       - chemical/x-mdl-molfile-v3000
     validationRules:
     - type: required
-      message: Must select column of 2D structures
+      message: Must select the column of cores produced by the R Group decomposition.
   request:
     id: coresColumn
     dataType: string
     selectorType: column
 - control:
     id: rGroupColumns
-    label: R Group columns to replace
+    label: R Group columns from R Group Decomposition
     type: columnselect
     multi: !!bool true
     filters:
@@ -86,6 +87,7 @@ inputFields:
       contentType: chemical/x-daylight-smiles
     validationRules:
     - type: required
+      message: Must select at least 1 column of R Groups
     tooltip: Select all the R Group columns from the R Group Decomposition.  These groups will be replaced by Top 500 replacements.
   request:
     id: rGroupColumns

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -38,6 +38,10 @@ inputFields:
     validationRules:
     - type: required
       message: ''
+  request:
+    id: idColumn
+    dataType: string
+    selectorType: column
 - control:
     id: useLayer1
     label: Use Layer 1 replacements

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -47,6 +47,7 @@ inputFields:
     id: coresColumn
     label: Select Cores column
     type: columnselect
+    tooltip: Select the column of cores produced by the R Group decomposition.
     filters:
     - dataType: string
       contentType:
@@ -87,6 +88,8 @@ inputFields:
       contentType: chemical/x-daylight-smiles
     validationRules:
     - type: required
+      message: Must select at least 1 column of R Groups
+    - type: oneOrMoreRequired
       message: Must select at least 1 column of R Groups
     tooltip: Select all the R Group columns from the R Group Decomposition.  These groups will be replaced by Top 500 replacements.
   request:

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -109,15 +109,6 @@ inputFields:
     id: useLayer2
     dataType: boolean
     data: !!bool false
-- control:
-    id: incOrigRGroups
-    label: Include original R Groups
-    type: checkbox
-    tooltip: When doing the replacements, include the original R Group in the substitution list, so that no change at that position is included in the products.
-  request:
-    id: incOrigRGroups
-    dataType: boolean
-    data: !!bool false
 tags:
 - color: '#50AF28'
   text: chemistry

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -65,8 +65,8 @@ inputFields:
     dataType: string
     selectorType: column
 - control:
-    id: allRGroupColumns
-    label: All R Group columns
+    id: rGroupColumns
+    label: R Group columns
     type: columnselect
     multi: !!bool true
     filters:
@@ -88,34 +88,7 @@ inputFields:
     - type: required
     tooltip: Select all the R Group columns from the R Group Decomposition that are in the table
   request:
-    id: allRGroupColumns
-    dataType: list(string)
-    selectorType: column
-- control:
-    id: rGroupColumnsToUse
-    label: R Group columns to replace from Top 500 substitutions table
-    type: columnselect
-    multi: !!bool true
-    tooltip: Select the R Group columns that you want to be varied in the output molecules.  The remainder will be kept as the original value from the parent molecule.  If left blank, all R Groups will be varied.
-    validationRules: []
-    filters:
-    - dataType:
-      - binary
-      contentType:
-      - chemical/x-mdl-molfile
-      - chemical/x-mdl-molfile-v3000
-    - dataType: string
-      contentType:
-      - chemical/x-mdl-molfile
-      - chemical/x-mdl-molfile-v3000
-    - dataType: string
-      contentType:
-      - chemical/x-smiles
-    - dataType: string
-      contentType:
-      - chemical/x-daylight-smiles
-  request:
-    id: rGroupColumnsToUse
+    id: rGroupColumns
     dataType: list(string)
     selectorType: column
 - control:

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -30,6 +30,15 @@ inputFields:
     dataType: string
     selectorType: column
 - control:
+    id: idColumn
+    label: Column of IDs
+    type: columnselect
+    multi: !!bool false
+    tooltip: Column to use for IDs of input structures for filtering analogues
+    validationRules:
+    - type: required
+      message: ''
+- control:
     id: useLayer1
     label: Use Layer 1 replacements
     type: checkbox

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -65,10 +65,11 @@ inputFields:
     dataType: string
     selectorType: column
 - control:
-    id: rGroupColumns
-    label: R Group columns
+    id: allRGroupColumns
+    label: All R Group columns
     type: columnselect
     multi: !!bool true
+    tooltip: Select all the R Group columns from the R Group Decomposition that are in the table
     filters:
     - dataType: binary
       contentType:
@@ -85,7 +86,32 @@ inputFields:
     validationRules:
     - type: required
   request:
-    id: rGroupColumns
+    id: allRGroupColumns
+    dataType: list(string)
+    selectorType: column
+- control:
+    id: rGroupColumnsToUse
+    label: R Group columns to replace from Top 500 substitutions table
+    type: columnselect
+    multi: !!bool true
+    tooltip: Select the R Group columns that you want to be varied in the output molecules.  The remainder will be kept as the original value from the parent molecule.  If left blank, all R Groups will be varied.
+    filters:
+    - dataType: binary
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+    - dataType: string
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+    - dataType: string
+      contentType: chemical/x-smiles
+    - dataType: string
+      contentType: chemical/x-daylight-smiles
+    validationRules:
+    - type: required
+  request:
+    id: rGroupColumnsToUse
     dataType: list(string)
     selectorType: column
 - control:

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -92,6 +92,33 @@ inputFields:
     dataType: list(string)
     selectorType: column
 - control:
+    id: rGroupColumnsToUse
+    label: R Group columns to use
+    type: columnselect
+    multi: !!bool true
+    filters:
+    - dataType:
+      - binary
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+    - dataType: string
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+    - dataType: string
+      contentType:
+      - chemical/x-smiles
+    - dataType: string
+      contentType: chemical/x-daylight-smiles
+    validationRules:
+    - type: required
+    tooltip: Select the R Groups to use be replaced
+  request:
+    id: rGroupColumnsToUse
+    dataType: list(string)
+    selectorType: column
+- control:
     id: useLayer1
     label: Use Layer 1 replacements
     type: checkbox

--- a/python/local/RGroupReplacement.yaml
+++ b/python/local/RGroupReplacement.yaml
@@ -3,7 +3,7 @@ name: R Group Replacement
 description: 'Uses the Top 500 R Group replacement data of Bajorath et al. to suggest produce analogues of the input molecules. '
 category: Chemistry
 version: 1.0.0
-serviceName: RGroupSubstitution
+serviceName: RGroupReplacement
 serviceUri: glysade.python
 executorId: Glysade.CPythonDataFxn
 inputFields:
@@ -31,7 +31,7 @@ inputFields:
     selectorType: column
 - control:
     id: useLayer1
-    label: Use Layer 1 substiutions
+    label: Use Layer 1 replacements
     type: checkbox
     tooltip: The direct replacements
   request:
@@ -39,9 +39,9 @@ inputFields:
     dataType: boolean
 - control:
     id: useLayer2
-    label: User Layer 2 substitutions
+    label: User Layer 2 replacements
     type: checkbox
-    tooltip: Layer 2 substitutions are nearest neighbours of their parent Layer 1 substitution.
+    tooltip: Layer 2 replacements are nearest neighbours of their parent Layer 1 replacement.
   request:
     id: useLayer2
     dataType: boolean

--- a/python/local/RGroupSubstitution.yaml
+++ b/python/local/RGroupSubstitution.yaml
@@ -1,0 +1,97 @@
+id: 0227312a-b83e-9777-d285-196c05263676
+name: R Group Replacement
+description: 'Uses the Top 500 R Group replacement data of Bajorath et al. to suggest produce analogues of the input molecules. '
+category: Chemistry
+version: 1.0.0
+serviceName: RGroupSubstitution
+serviceUri: glysade.python
+executorId: Glysade.CPythonDataFxn
+inputFields:
+- control:
+    id: structureColumn
+    label: Select structure column
+    type: columnselect
+    filters:
+    - dataType: string
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+      - chemical/x-smiles
+      - chemical/x-daylight-smiles
+    - dataType: binary
+      contentType:
+      - chemical/x-mdl-molfile
+      - chemical/x-mdl-molfile-v3000
+    validationRules:
+    - type: required
+      message: Must select column of 2D structures
+  request:
+    id: structureColumn
+    dataType: string
+    selectorType: column
+- control:
+    id: useLayer1
+    label: Use Layer 1 substiutions
+    type: checkbox
+    tooltip: The direct replacements
+  request:
+    id: useLayer1
+    dataType: boolean
+- control:
+    id: useLayer2
+    label: User Layer 2 substitutions
+    type: checkbox
+    tooltip: Layer 2 substitutions are nearest neighbours of their parent Layer 1 substitution.
+  request:
+    id: useLayer2
+    dataType: boolean
+- control:
+    id: coreSMARTS
+    label: SMARTS defining core of molecules
+    type: text
+    tooltip: A core is needed so the R Groups can be identified.
+  request:
+    id: coreSMARTS
+    dataType: string
+- control:
+    id: coreSketcher
+    label: Sketch defining core
+    type: molecule
+    molTypes:
+    - extension: .smi
+      contentType: smiles
+      name: SMILES (*.smi)
+    - extension: .sdf
+      contentType: chemical/x-mdl-sdfile
+      name: SD file (*.sdf)
+    - extension: .mol
+      contentType: chemical/x-mdl-molfile
+      name: MOL file (*.mol)
+    tooltip: Note that this is a query molecule, so aromatic rings must be specified correctly.
+  request:
+    id: coreSketcher
+    dataType: string
+    contentType: chemical/x-mdl-molfile
+tags:
+- color: '#50AF28'
+  text: chemistry
+- color: '#c6fc00'
+  text: calcprop
+updateBehavior: automatic
+maximumOutputColumns: !!int 0
+maximumOutputTables: !!int 1
+chemistryFunction: !!bool false
+outputFields:
+- id: structureColumn
+  source: inputField
+  type: default
+  name: Structure column
+- id: column1
+  source: column
+  type: filter
+  name: Output exact mass column
+allowedClients:
+- Analyst
+- WebPlayer
+demoUrl: 
+limitBy: none

--- a/python/local/RGroupSubstitution.yaml
+++ b/python/local/RGroupSubstitution.yaml
@@ -82,14 +82,10 @@ maximumOutputColumns: !!int 0
 maximumOutputTables: !!int 1
 chemistryFunction: !!bool false
 outputFields:
-- id: structureColumn
-  source: inputField
-  type: default
-  name: Structure column
-- id: column1
-  source: column
-  type: filter
-  name: Output exact mass column
+  - id: table1
+    source: table
+    type: default
+    name: Output R Group Replacements table
 allowedClients:
 - Analyst
 - WebPlayer


### PR DESCRIPTION
It defaults to Layer 1 on, Layer 2 off.
It has 2 input fields for the core, but only one should be used at a time.  They should probably be set up as some sort of mutually-exclusive arrangement.
The script will prefer the SMARTS core if both are provided.