### PR TITLE
Fix crash when minMCSMols >= number of molecules in input set.

### DIFF
--- a/python/local/MaximumCommonSubstructure.yaml
+++ b/python/local/MaximumCommonSubstructure.yaml
@@ -330,6 +330,8 @@ script: |
       """
       mcss = []
       nmols = len(mols)
+      if min_mol_num > nmols:
+          min_mol_num = nmols
   
       def stirling_fac(n):
           twopi = Decimal(2 * math.pi)
@@ -338,7 +340,10 @@ script: |
   
       nmol_fac = stirling_fac(Decimal(nmols))
       min_mol_num_fac = stirling_fac(Decimal(min_mol_num))
-      diff_fac = stirling_fac(Decimal(nmols - min_mol_num))
+      if min_mol_num == nmols:
+          diff_fac = 1
+      else:
+          diff_fac = stirling_fac(Decimal(nmols - min_mol_num))
       approx_ncomb = int(nmol_fac / (min_mol_num_fac * diff_fac))
       print(f'Approximate number of MCS determinations : {approx_ncomb}')
   


### PR DESCRIPTION
An exception was being raised if the user was so uncouth as to ask for more molecules in an MCS cluster than there were in the input set.
It was nothing to do with an empty table being returned, the branch name demonstrating that the bug isn't always where you think it is when you set out.
