### PR TITLE
Feature/blast search new databases 230605

### DIFF
--- a/python/local/BlastLocalColumnSearch.yaml
+++ b/python/local/BlastLocalColumnSearch.yaml
@@ -7,133 +7,133 @@ serviceName: BlastLocalColumnSearch
 serviceUri: glysade.python
 executorId: Glysade.CPythonDataFxn
 inputFields:
-- control:
-    id: sequenceColumn
-    label: Select sequence column
-    type: columnselect
-    filters:
-    - dataType: string
-      contentType: chemical/x-sequence
-    - dataType: binary
-      contentType: chemical/x-genbank
-    validationRules:
-    - type: required
-      message: Must select column of sequences
-  request:
-    id: sequenceColumn
-    dataType: string
-    selectorType: column
-- control:
-    id: idColumn
-    label: ID Column (optional)
-    type: columnselect
-    multi: !!bool false
-    filters:
-    - dataType:
-      - string
-      - int
-    tooltip: ID column is not required for Genbank encoded sequences
-  request:
-    id: idColumn
-    dataType: string
-    selectorType: column
-- control:
-    id: method
-    label: Select method
-    type: select
-    options:
-    - text: 'BLASTP: protein(q)-protein(d)'
-      value: BLASTP
-    - text: 'BLASTN: nucleotide(q)-nucleotide(d)'
-      value: BLASTN
-    - text: 'BLASTX: nucleotide(q)+translation-protein(d)'
-      value: BLASTX
-    - text: 'TBLASTN: protein(q)-nucleotide(d)+translation'
-      value: TBLASTN
-    - text: 'TBLASTX: nucleotide(q)+translation-nucleotide(d)+translation'
-      value: TBLASTX
-    validationRules:
-    - type: required
-  request:
-    id: method
-    dataType: string
-    data: BLASTP
-- control:
-    id: databaseName
-    label: Select database
-    type: select
-    options:
-    - text: Human NCBI NR
-      value: human_nr
-    - text: Human Uniprot SwissProt
-      value: up_sp_human
-    - text: Human Uniprot Trembl
-      value: up_tbl_human
-    - text: Human PDB
-      value: human_pdbaa
-    - text: Human Patented Proteins
-      value: human_pataa
-    - text: Human NCBI NT
-      value: human_nt
-    - text: Human EBI ENA
-      value: ena_cd_human
-    - text: Human Patented Nucleotides
-      value: human_patnt 
-    - text: Human IG Germline (Proteins)
-      value: human_IG_germline
-    - text: Mouse NCBI NR
-      value: mouse_nr
-    - text: Mouse PDB
-      value: mouse_pdbaa
-    - text: Mouse Patented Proteins
-      value: mouse_pataa
-    - text: Mouse NCBI NT
-      value: mouse_nt
-    - text: Mouse Patented Nucleotides
-      value: mouse_patnt 
-    - text: Rat NCBI NR
-      value: rat_nr
-    - text: Rat PDB
-      value: rat_pdbaa
-    - text: Rat Patented Proteins
-      value: rat_pataa
-    - text: Rat NCBI NT
-      value: rat_nt
-    - text: Rat Patented Nucleotides
-      value: rat_patnt 
-    validationRules:
-    - type: required
-  request:
-    id: databaseName
-    dataType: string
-- control:
-    id: maxHits
-    label: Max hits
-    type: text
-    validationRules:
-    - type: required
-      message: Must enter a value between 1 and 5000
-    - type: range
-      min: !!int 1
-      max: !!int 5000
-      message: Max hits must be a value between 1 and 5000
-  request:
-    id: maxHits
-    dataType: integer
-    data: !!int 100
-- control:
-    id: blastDbPath
-    label: Directory containing BLAST databases
-    type: file
-    mode: path
-    pathType: folder
-    validationRules:
-    - type: required
-      message: ''
-  request:
-    id: blastDbPath
-    dataType: string
-    data: C:\db\ncbi
+  - control:
+      id: sequenceColumn
+      label: Select sequence column
+      type: columnselect
+      filters:
+      - dataType: string
+        contentType: chemical/x-sequence
+      - dataType: binary
+        contentType: chemical/x-genbank
+      validationRules:
+      - type: required
+        message: Must select column of sequences
+    request:
+      id: sequenceColumn
+      dataType: string
+      selectorType: column
+  - control:
+      id: idColumn
+      label: ID Column (optional)
+      type: columnselect
+      multi: !!bool false
+      filters:
+      - dataType:
+        - string
+        - int
+      tooltip: ID column is not required for Genbank encoded sequences
+    request:
+      id: idColumn
+      dataType: string
+      selectorType: column
+  - control:
+      id: method
+      label: Select method
+      type: select
+      options:
+      - text: 'BLASTP: protein(q)-protein(d)'
+        value: BLASTP
+      - text: 'BLASTN: nucleotide(q)-nucleotide(d)'
+        value: BLASTN
+      - text: 'BLASTX: nucleotide(q)+translation-protein(d)'
+        value: BLASTX
+      - text: 'TBLASTN: protein(q)-nucleotide(d)+translation'
+        value: TBLASTN
+      - text: 'TBLASTX: nucleotide(q)+translation-nucleotide(d)+translation'
+        value: TBLASTX
+      validationRules:
+      - type: required
+    request:
+      id: method
+      dataType: string
+      data: BLASTP
+  - control:
+      id: databaseName
+      label: Select database
+      type: select
+      options:
+      - text: Human NCBI NR
+        value: human_nr
+      - text: Human Uniprot SwissProt
+        value: up_sp_human
+      - text: Human Uniprot Trembl
+        value: up_tbl_human
+      - text: Human PDB
+        value: human_pdbaa
+      - text: Human Patented Proteins
+        value: human_pataa
+      - text: Human NCBI NT
+        value: human_nt
+      - text: Human EBI ENA
+        value: ena_cd_human
+      - text: Human Patented Nucleotides
+        value: human_patnt 
+      - text: Human IG Germline (Proteins)
+        value: human_IG_germline
+      - text: Mouse NCBI NR
+        value: mouse_nr
+      - text: Mouse PDB
+        value: mouse_pdbaa
+      - text: Mouse Patented Proteins
+        value: mouse_pataa
+      - text: Mouse NCBI NT
+        value: mouse_nt
+      - text: Mouse Patented Nucleotides
+        value: mouse_patnt 
+      - text: Rat NCBI NR
+        value: rat_nr
+      - text: Rat PDB
+        value: rat_pdbaa
+      - text: Rat Patented Proteins
+        value: rat_pataa
+      - text: Rat NCBI NT
+        value: rat_nt
+      - text: Rat Patented Nucleotides
+        value: rat_patnt 
+      validationRules:
+      - type: required
+    request:
+      id: databaseName
+      dataType: string
+  - control:
+      id: maxHits
+      label: Max hits
+      type: text
+      validationRules:
+      - type: required
+        message: Must enter a value between 1 and 5000
+      - type: range
+        min: !!int 1
+        max: !!int 5000
+        message: Max hits must be a value between 1 and 5000
+    request:
+      id: maxHits
+      dataType: integer
+      data: !!int 100
+  - control:
+      id: blastDbPath
+      label: Directory containing BLAST databases
+      type: file
+      mode: path
+      pathType: folder
+      validationRules:
+      - type: required
+        message: ''
+    request:
+      id: blastDbPath
+      dataType: string
+      data: C:\db\ncbi
 tags:
   - color : '#337abc'
     text  : sequence

--- a/python/local/BlastLocalColumnSearch.yaml
+++ b/python/local/BlastLocalColumnSearch.yaml
@@ -73,14 +73,14 @@ inputFields:
         value: human_pdbaa
       - text: Human Patented Proteins
         value: human_pataa
+      - text: Human IG Germline (Proteins)
+        value: human_IG_germline
       - text: Human NCBI NT
         value: human_nt
       - text: Human EBI ENA
         value: ena_cd_human
       - text: Human Patented Nucleotides
         value: human_patnt 
-      - text: Human IG Germline (Proteins)
-        value: human_IG_germline
       - text: Mouse NCBI NR
         value: mouse_nr
       - text: Mouse PDB

--- a/python/local/BlastLocalColumnSearch.yaml
+++ b/python/local/BlastLocalColumnSearch.yaml
@@ -1,8 +1,8 @@
 id: b486f3d0-e778-ace1-51a2-63934f1910a5
 name: Blast Local Column Search
-description: Performs a BLAST search of user selected databases using queries from a sequence column.  Please contact business@glysade.com for the latest database download link.
+description: Performs a BLAST search of user selected databases using queries from a sequence column. Pre-configured BLAST databases can be downloaded from https://tinyurl.com/3d38p356
 category: Biopolymer
-version: 1.0.0
+version: 1.1.0
 serviceName: BlastLocalColumnSearch
 serviceUri: glysade.python
 executorId: Glysade.CPythonDataFxn

--- a/python/local/BlastLocalColumnSearch.yaml
+++ b/python/local/BlastLocalColumnSearch.yaml
@@ -69,20 +69,38 @@ inputFields:
       value: up_sp_human
     - text: Human Uniprot Trembl
       value: up_tbl_human
+    - text: Human PDB
+      value: human_pdbaa
+    - text: Human Patented Proteins
+      value: human_pataa
     - text: Human NCBI NT
       value: human_nt
     - text: Human EBI ENA
       value: ena_cd_human
-    - text: Mouse NCBI NR
-      value: mouse_nr
-    - text: Mouse NCBI NT
-      value: mouse_nt
-    - text: Rat NCBI NR
-      value: rat_nr
-    - text: Rat NCBI NT
-      value: rat_nt
+    - text: Human Patented Nucleotides
+      value: human_patnt 
     - text: Human IG Germline (Proteins)
       value: human_IG_germline
+    - text: Mouse NCBI NR
+      value: mouse_nr
+    - text: Mouse PDB
+      value: mouse_pdbaa
+    - text: Mouse Patented Proteins
+      value: mouse_pataa
+    - text: Mouse NCBI NT
+      value: mouse_nt
+    - text: Mouse Patented Nucleotides
+      value: mouse_patnt 
+    - text: Rat NCBI NR
+      value: rat_nr
+    - text: Rat PDB
+      value: rat_pdbaa
+    - text: Rat Patented Proteins
+      value: rat_pataa
+    - text: Rat NCBI NT
+      value: rat_nt
+    - text: Rat Patented Nucleotides
+      value: rat_patnt 
     validationRules:
     - type: required
   request:

--- a/python/local/BlastLocalTextSearch.yaml
+++ b/python/local/BlastLocalTextSearch.yaml
@@ -128,7 +128,6 @@ inputFields:
       id: blastDbPath
       dataType: string
       data: C:\db\ncbi
-description: Performs a BLAST search of user selected databases using a query entered as text
 category: Biopolymer
 maximumOutputColumns: !!int 0
 maximumOutputTables: !!int 1

--- a/python/local/BlastLocalTextSearch.yaml
+++ b/python/local/BlastLocalTextSearch.yaml
@@ -1,9 +1,10 @@
 id: 099f6c94-7e66-4150-b751-88fbe2b9053a
 name: Blast Local Text Search
+description: Performs a BLAST search of user selected databases using an input sequence. Pre-configured BLAST databases can be downloaded from https://tinyurl.com/3d38p35
 serviceName: BlastLocalTextSearch
 executorId: Glysade.CPythonDataFxn
 serviceUri: glysade.python
-version: 1.0.0
+version: 1.1.0
 inputFields:
   - control:
       id: query

--- a/python/local/BlastLocalTextSearch.yaml
+++ b/python/local/BlastLocalTextSearch.yaml
@@ -58,14 +58,14 @@ inputFields:
           value: human_pdbaa
         - text: Human Patented Proteins
           value: human_pataa
+        - text: Human IG Germline (Proteins)
+          value: human_IG_germline
         - text: Human NCBI NT
           value: human_nt
         - text: Human EBI ENA
           value: ena_cd_human
         - text: Human Patented Nucleotides
           value: human_patnt 
-        - text: Human IG Germline (Proteins)
-          value: human_IG_germline
         - text: Mouse NCBI NR
           value: mouse_nr
         - text: Mouse PDB

--- a/python/local/BlastLocalTextSearch.yaml
+++ b/python/local/BlastLocalTextSearch.yaml
@@ -1,6 +1,6 @@
 id: 099f6c94-7e66-4150-b751-88fbe2b9053a
 name: Blast Local Text Search
-description: Performs a BLAST search of user selected databases using an input sequence. Pre-configured BLAST databases can be downloaded from https://tinyurl.com/3d38p35
+description: Performs a BLAST search of user selected databases using an input sequence. Pre-configured BLAST databases can be downloaded from https://tinyurl.com/3d38p356
 serviceName: BlastLocalTextSearch
 executorId: Glysade.CPythonDataFxn
 serviceUri: glysade.python

--- a/python/local/BlastLocalTextSearch.yaml
+++ b/python/local/BlastLocalTextSearch.yaml
@@ -54,20 +54,38 @@ inputFields:
           value: up_sp_human
         - text: Human Uniprot Trembl
           value: up_tbl_human
+        - text: Human PDB
+          value: human_pdbaa
+        - text: Human Patented Proteins
+          value: human_pataa
         - text: Human NCBI NT
           value: human_nt
         - text: Human EBI ENA
           value: ena_cd_human
-        - text: Mouse NCBI NR
-          value: mouse_nr
-        - text: Mouse NCBI NT
-          value: mouse_nt
-        - text: Rat NCBI NR
-          value: rat_nr
-        - text: Rat NCBI NT
-          value: rat_nt
+        - text: Human Patented Nucleotides
+          value: human_patnt 
         - text: Human IG Germline (Proteins)
           value: human_IG_germline
+        - text: Mouse NCBI NR
+          value: mouse_nr
+        - text: Mouse PDB
+          value: mouse_pdbaa
+        - text: Mouse Patented Proteins
+          value: mouse_pataa
+        - text: Mouse NCBI NT
+          value: mouse_nt
+        - text: Mouse Patented Nucleotides
+          value: mouse_patnt 
+        - text: Rat NCBI NR
+          value: rat_nr
+        - text: Rat PDB
+          value: rat_pdbaa
+        - text: Rat Patented Proteins
+          value: rat_pataa
+        - text: Rat NCBI NT
+          value: rat_nt
+        - text: Rat Patented Nucleotides
+          value: rat_patnt 
       validationRules:
         - type: required
     request:


### PR DESCRIPTION
This adds the new databases (PDB, patented nucleotides, and patented proteins) to database options for BLAST Local Text Search and BLAST Column Search.

Existing tests in DataFxnPylibTests succeed and do not appear to need adjustment given what they currently tests.  When running the test for BLAST Local Text Search, I see a list of warnings (head of that list is below) which do not seem to cause problems.  I get the same list of warnings when using the original set of databases as well.

```C:\Users\rkdel\dev\csharp\dev\glysadepython\Python\python.exe "C:/Program Files/JetBrains/PyCharm Community Edition 2023.1.1/plugins/python-ce/helpers/pycharm/_jb_unittest_runner.py" --target test_data_functions.DataFunctionTest.test_named_data_function_blast_local_text_search 
Testing started at 2:49 PM ...
Launching unittests with arguments python -m unittest test_data_functions.DataFunctionTest.test_named_data_function_blast_local_text_search in C:\Users\rkdel\dev\python\DataFxnPylibTest\test_df

Unable to find Entrez identifier in hit target id IGKV4-1*02 or definition No definition line
Unable to find Entrez identifier in hit target id IGKV4-1*01 or definition No definition line
Unable to find Entrez identifier in hit target id IGKV2D-28*01 or definition No definition line
Unable to find Entrez identifier in hit target id IGKV2-28*01 or definition No definition line
Unable to find Entrez identifier in hit target id IGKV3-7*04 or definition No definition line```