### PR TITLE
Feature/extract genbank to table 240114

### DIFF
--- a/python/local/ExtractGenbankRegions.yaml
+++ b/python/local/ExtractGenbankRegions.yaml
@@ -22,6 +22,16 @@ inputFields:
     dataType: string
     selectorType: column
 - control:
+    id: uiIDColumn
+    label: Select Unique ID column
+    type: columnselect
+    multi: !!bool false
+    tooltip: Select a column with unique IDs for each row.
+  request:
+    id: uiIDColumn
+    dataType: string
+    selectorType: column
+- control:
     id: featureKey
     label: Feature key
     type: text

--- a/python/local/ExtractGenbankRegions.yaml
+++ b/python/local/ExtractGenbankRegions.yaml
@@ -74,6 +74,50 @@ tags:
   text: sequence
 - color: '#e2f062'
   text: tform
+ironPython: |
+  ####################################################
+  #  Copyright 2024 Glysade LLC, All Rights Reserved #
+  ####################################################
+
+  import sys,clr
+  from Spotfire.Dxp.Data import DataTable, DataManager
+  from Spotfire.Dxp.Application import PanelTypeIdentifiers
+  from Spotfire.Dxp.Application import Panel
+  import Spotfire.Dxp.Application.PanelCollection
+
+  from System import AppDomain
+  for asm in AppDomain.CurrentDomain.GetAssemblies():
+      if asm.GetName().Name == 'Charts':
+          clr.AddReference(asm.FullName)
+
+  from Charts import ChartsModel
+  model_type = ChartsModel
+
+  #tableId pass in args
+  dataTable = ResultTables[0]
+
+  if not dataTable:
+      raise Exception('target table not found')
+
+  page = Document.Pages.AddNew('Extract Genbank Regions Results')
+  panelsToHide = [PanelTypeIdentifiers.DataPanel, PanelTypeIdentifiers.DetailsOnDemandPanel]
+
+  for panel in page.Panels:
+      if panel.TypeId in panelsToHide:
+          if panel.Visible:
+              panel.Visible = False
+
+  filteringScheme = Document.FilteringSchemes[0]
+  page.FilterPanel.FilteringSchemeReference = filteringScheme
+
+  tableVis = page.Visuals.AddNew[model_type]()
+  tableVis.SetKeyValue('visualization','table-visualization')
+  tableVis.DataTable = dataTable
+  tableVis.ConfigureColumns()
+  tableVis.Marking = Document.Data.Markings.DefaultMarkingReference
+
+  tableVis.SetActiveVisual()
+  page.AutoConfigure()
 updateBehavior: automatic
 maximumOutputColumns: !!int 100
 maximumOutputTables: !!int 1

--- a/python/local/ExtractGenbankRegions.yaml
+++ b/python/local/ExtractGenbankRegions.yaml
@@ -1,8 +1,8 @@
 id: fa95f9fa-27b8-67cc-9b3d-583f7ee9c82f
 name: Extract Genbank Regions
-description: Extracts all regions matching a feature key and qualifier from a column of genbank sequences into new columns
+description: Extracts all regions matching a feature key and qualifier from a column of Genbank sequences into new columns.
 category: Biopolymer
-version: 1.0.0
+version: 1.1.0
 serviceName: ExtractGenbankRegions
 serviceUri: glysade.python
 executorId: Glysade.CPythonDataFxn
@@ -35,12 +35,10 @@ inputFields:
     data: region
 - control:
     id: featureQualifier
-    label: Feature qualifier
+    label: Feature qualifier (optional)
     type: text
     tooltip: The qualifier whose value will be used as the region name
-    validationRules:
-    - type: required
-      message: ''
+    validationRules: []
   request:
     id: featureQualifier
     dataType: string
@@ -68,9 +66,12 @@ tags:
   text: tform
 updateBehavior: automatic
 maximumOutputColumns: !!int 100
-maximumOutputTables: !!int 0
+maximumOutputTables: !!int 1
 chemistryFunction: !!bool false
 allowedClients:
 - Analyst
 - WebPlayer
+demoUrl: 
 limitBy: none
+minimumChartsVersion: 
+confirmSubmit: 


### PR DESCRIPTION
Extract Genbank Sequences extended with new functionality:
* Retains old functionality - specification of Feature Key and Feature Qualifier leads to new columns in the same table
* Leaving out Feature Qualifier only extracts information at the Feature Key level
   * A new table is created
   * IDs are carried from original table to new table (to allow joins later, if wanted)
      * Tolerant to missing IDs by either creating all fake IDS (Row 1, Row 2, ...) when no ID column specified, or filling in missing values with appropriate Row #.
   * If there are multiple Feature Keys with the same name, additional rows are created in the table for each.
      * Each row is unique by one-to-many relationship of the original ID (one) with the one row per instance of a Feature Key (many) in the output table. 
   * New table shows ID (original or faked), sequence of extracted region, description extracted from the Genbank file (first Feature Qualifier for specified Feature Key), start and end sites from the original sequence.

Parallel with similar PR in DataFxnPylib.  DataFxnPylibTest in process - new functionality breaks old tests, but a wealth of new tests are available and need to be completed.